### PR TITLE
Fix unsync sorting experience

### DIFF
--- a/src/components/ResultsTable/ResultsTableHead.tsx
+++ b/src/components/ResultsTable/ResultsTableHead.tsx
@@ -13,15 +13,19 @@ const ResultsTableHead = <DataItem extends Record<string, any>>({
   const [sortBy, setSortBy] = useState<string>(initSortBy)
   const [sortOrder, setSortOrder] = useState<SortOrderType>(initSortOrder ?? SortOrderType.DESC)
 
+  const getNewSortOrder = (newColumnId: string, prevSortOrder: SortOrderType) => {
+    let newSortOrder = prevSortOrder === SortOrderType.ASC ? SortOrderType.DESC : SortOrderType.ASC
+    if (sortBy !== newColumnId) {
+      newSortOrder = SortOrderType.ASC
+    }
+    return newSortOrder
+  }
+
   const handleSort = (columnId: string) => () => {
-    setSortOrder((prevSortOrder: SortOrderType) => {
-      let newSortOrder = prevSortOrder === SortOrderType.ASC ? SortOrderType.DESC : SortOrderType.ASC
-      if (sortBy !== columnId) {
-        newSortOrder = SortOrderType.ASC
-      }
-      return newSortOrder
-    })
-    setSortBy(columnId)
+    setSortOrder((prevSortOrder: SortOrderType) => getNewSortOrder(columnId, prevSortOrder))
+    if (columnId !== sortBy) {
+      setSortBy(columnId)
+    }
   }
 
   useEffect(() => {

--- a/src/components/ResultsTable/ResultsTableHead.tsx
+++ b/src/components/ResultsTable/ResultsTableHead.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { TableHead, TableRow, TableSortLabel } from '@mui/material'
 import { ResultsTableHeadProps, SortOrderType } from '../../types/ResultsTable'
@@ -10,15 +10,23 @@ const ResultsTableHead = <DataItem extends Record<string, any>>({
   sortOrder: initSortOrder,
   onSortChange
 }: ResultsTableHeadProps<DataItem>) => {
-  const [sortBy, setSortBy] = useState<keyof DataItem | string>(initSortBy)
+  const [sortBy, setSortBy] = useState<string>(initSortBy)
   const [sortOrder, setSortOrder] = useState<SortOrderType>(initSortOrder ?? SortOrderType.DESC)
 
   const handleSort = (columnId: string) => () => {
-    const isAsc = sortBy === columnId && sortOrder === SortOrderType.ASC
-    setSortOrder(isAsc ? SortOrderType.DESC : SortOrderType.ASC)
+    setSortOrder((prevSortOrder: SortOrderType) => {
+      let newSortOrder = prevSortOrder === SortOrderType.ASC ? SortOrderType.DESC : SortOrderType.ASC
+      if (sortBy !== columnId) {
+        newSortOrder = SortOrderType.ASC
+      }
+      return newSortOrder
+    })
     setSortBy(columnId)
-    onSortChange(columnId as string, sortOrder)
   }
+
+  useEffect(() => {
+    onSortChange(sortBy, sortOrder)
+  }, [sortBy, sortOrder])
 
   return (
     <TableHead>

--- a/src/pages/ReactRepos/__mocks__/repositories-sample-data.ts
+++ b/src/pages/ReactRepos/__mocks__/repositories-sample-data.ts
@@ -95,7 +95,7 @@ export const mocks = ({ repositories, hasNextPage, hasError = false }: GetMocksP
         {
           request: {
             query: REACT_REPOSITORIES_QUERY,
-            variables: { queryString: 'topic:ReactJS  language:javascript sort:repo-desc', first: 10 }
+            variables: { queryString: 'topic:ReactJS  language:javascript sort:name-asc', first: 10 }
           },
           errors: new Error('error')
         }
@@ -104,7 +104,7 @@ export const mocks = ({ repositories, hasNextPage, hasError = false }: GetMocksP
         {
           request: {
             query: REACT_REPOSITORIES_QUERY,
-            variables: { queryString: 'topic:ReactJS  language:javascript sort:repo-desc', first: 10 }
+            variables: { queryString: 'topic:ReactJS  language:javascript sort:name-asc', first: 10 }
           },
           result: {
             data: {

--- a/src/pages/ReactRepos/hooks/__tests__/useReactRepos.test.tsx
+++ b/src/pages/ReactRepos/hooks/__tests__/useReactRepos.test.tsx
@@ -19,7 +19,7 @@ describe('useReactRepos', () => {
     renderHook(() => useReactRepos())
     expect(searchRepositoriesMock).toHaveBeenCalled()
     expect(searchRepositoriesMock).toHaveBeenCalledWith({
-      variables: { first: 10, queryString: 'topic:ReactJS  language:javascript sort:repo-desc' }
+      variables: { first: 10, queryString: 'topic:ReactJS  language:javascript sort:name-asc' }
     })
   })
 
@@ -68,7 +68,7 @@ describe('useReactRepos', () => {
     })
     expect(searchRepositoriesMock).toHaveBeenCalledTimes(2)
     expect(searchRepositoriesMock).toHaveBeenCalledWith({
-      variables: { first: 10, queryString: 'topic:ReactJS my repos language:javascript sort:repo-desc' }
+      variables: { first: 10, queryString: 'topic:ReactJS my repos language:javascript sort:name-asc' }
     })
   })
 })

--- a/src/pages/ReactRepos/hooks/useReactRepos.tsx
+++ b/src/pages/ReactRepos/hooks/useReactRepos.tsx
@@ -13,8 +13,8 @@ import { SortOrderType } from '../../../types/ResultsTable'
 const defaultRepositoriesState: RepositoriesState = {
   repositories: [],
   hasNextPage: true,
-  sortBy: 'repo',
-  sortOrder: SortOrderType.DESC,
+  sortBy: 'name',
+  sortOrder: SortOrderType.ASC,
   endCursor: null,
   totalItems: 0,
   searchValue: ''


### PR DESCRIPTION
## What?

An inconsistency was produced when setting the updated state of the sorting (both `sortBy` and `sortOrder`) in which the data were sent to the event in a non-updated status (was not sent with the latest state available.

## Solution

State is now applied calculating the new one based on the previous within the `set<STATE>` method for each.
A `useEffect` is required in order to ensure that the changes are batched and sent to the parent component only when the sorting criteria have stabilised. 

## Result:

![issue2](https://github.com/jottaxwds/my-react-repo-explorer/assets/35625576/069dff65-0e50-4946-9100-a5aa6911e0a2)


